### PR TITLE
To start with LDAP should not be in place

### DIFF
--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -27,9 +27,7 @@ targetCompatibility = 1.8
 // tag::security[]
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
-    compile("org.springframework.boot:spring-boot-starter-security")
-    compile("org.springframework.security:spring-security-ldap")
-    compile("org.springframework:spring-tx")
+
     compile("org.apache.directory.server:apacheds-server-jndi:1.5.5")
     testCompile("org.springframework.boot:spring-boot-starter-test")
     testCompile("org.springframework.security:spring-security-test")


### PR DESCRIPTION
The idea is of the exercise is to teach learners how LDAP can be added later, but the gradle file already includes the security dependencies in the initial folder.