### PR TITLE
Add shared-ldap dependency

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -31,6 +31,11 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-ldap</artifactId>
         </dependency>
+		<dependency>
+			<groupId>org.apache.directory.shared</groupId>
+			<artifactId>shared-ldap</artifactId>
+			<version>0.9.17</version>
+		</dependency>        
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-server-jndi</artifactId>


### PR DESCRIPTION
Error LdapNameNotFoundException is resolved by adding shared-ldap version 0.9.17
