### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,11 @@
 :spring_version: current
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
 :toc:
 :icons: font
 :source-highlighter: prettify
 :project_id: gs-authenticating-ldap
 
-This guide walks you through the process creating an application and securing it with the http://projects.spring.io/spring-security/[Spring Security] LDAP module.
+This guide walks you through the process creating an application and securing it with the https://projects.spring.io/spring-security/[Spring Security] LDAP module.
 
 == What you'll build
 
@@ -118,7 +118,7 @@ Welcome to the home page!
 
 == Summary
 
-Congratulations! You have just written a web application and secured it with http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/[Spring Security]. In this case, you used an http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#ldap[LDAP-based user store].
+Congratulations! You have just written a web application and secured it with https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/[Spring Security]. In this case, you used an https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#ldap[LDAP-based user store].
 
 == See Also
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/) result 200).
* [ ] http://projects.spring.io/spring-security/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-security/ ([https](https://projects.spring.io/spring-security/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 2 occurrences