### PR TITLE
Updated password encoder to BCryptPasswordEncoder

### DIFF
--- a/complete/src/main/java/com/example/authenticatingldap/WebSecurityConfig.java
+++ b/complete/src/main/java/com/example/authenticatingldap/WebSecurityConfig.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.crypto.password.LdapShaPasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @Configuration
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
@@ -28,7 +28,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 					.url("ldap://localhost:8389/dc=springframework,dc=org")
 					.and()
 				.passwordCompare()
-					.passwordEncoder(new LdapShaPasswordEncoder())
+					.passwordEncoder(new BCryptPasswordEncoder())
 					.passwordAttribute("userPassword");
 	}
 


### PR DESCRIPTION
LdapShaPasswordEncoder is deprecated. BCrypt is the current
recommended implementation of PasswordEncoder interface.